### PR TITLE
Get Error ConvertFrom-Json

### DIFF
--- a/Teams User Settings.ps1
+++ b/Teams User Settings.ps1
@@ -28,11 +28,8 @@ param(
 [boolean]$runningOnClose=$False
 )
 
-# Get Teams Configuration
-$FileContent=Get-Content -Path "$ENV:APPDATA\Microsoft\Teams\desktop-config.json"
-
-# Convert file content from JSON format to PowerShell object
-$JSONObject=ConvertFrom-Json -InputObject $FileContent
+## Get Teams Configuration and Convert file content from JSON format to PowerShell object
+$JSONObject=Get-Content -Raw -Path "$ENV:APPDATA\Microsoft\Teams\desktop-config.json" | ConvertFrom-Json
 
 # Update Object settings
 $JSONObject.appPreferenceSettings.disableGpu=$disableGpu


### PR DESCRIPTION
I get an error message when I run the script. After the change, it works perfectly.

ConvertFrom-Json : "System.Object[]" kann nicht in den Typ "System.String" konvertiert werden, der für den Parameter
"InputObject" erforderlich ist. Die angegebene Methode wird nicht unterstützt.
In \\XXXXXX\XXXXXX\XXXXX$\Scripts\TeamsUserSettings.ps1.ps1:35 Zeichen:43
+ $JSONObject=ConvertFrom-Json -InputObject $FileContent
+                                           ~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [ConvertFrom-Json], ParameterBindingException
    + FullyQualifiedErrorId : CannotConvertArgument,Microsoft.PowerShell.Commands.ConvertFromJsonCommand