### PR TITLE
add General>App Language support to the script

### DIFF
--- a/Teams User Settings.ps1
+++ b/Teams User Settings.ps1
@@ -17,7 +17,7 @@
 	    
     .NOTES
 	Execute as WEM external task, logonscript or task at logon
-	You can add seeting 
+	You can add setting 
 #>
 
 # Define settings
@@ -25,15 +25,31 @@ param(
 # Enable or disable GPU acceleration
 [boolean]$disableGpu=$True,
 # Fully close Teams App
-[boolean]$runningOnClose=$False
+[boolean]$runningOnClose=$False,
+# Current web language
+[string]$currentWebLanguage="en-US"
 )
 
 ## Get Teams Configuration and Convert file content from JSON format to PowerShell object
 $JSONObject=Get-Content -Raw -Path "$ENV:APPDATA\Microsoft\Teams\desktop-config.json" | ConvertFrom-Json
+## Define Cookies and Cookies-journal 
+##Some settings eg "Application language" wouldn't work unless these are deleted
+$cookiesFile = "$ENV:APPDATA\Microsoft\Teams\Cookies"
+$cookiesJournal = "$ENV:APPDATA\Microsoft\Teams\Cookies-journal"
+
+## Delete Cookies and Cookies-journal
+if ([System.IO.File]::Exists($cookiesFile)) {
+  Remove-Item $cookiesFile -Force
+}
+
+if ([System.IO.File]::Exists($cookiesJournal)) {
+  Remove-Item $cookiesJournal -Force
+}
 
 # Update Object settings
 $JSONObject.appPreferenceSettings.disableGpu=$disableGpu
 $JSONObject.appPreferenceSettings.runningOnClose=$runningOnClose
+$JSONObject.currentWebLanguage=$currentWebLanguage
 $NewFileContent=$JSONObject | ConvertTo-Json
 
 # Update configuration in file


### PR DESCRIPTION
Teams default settings for "App language" are en-US. We previously had some time/date format related issues when opening Excel files from within Teams. It might be because of a different issue (Excel online for our tenant was defaulting to en-US even though the MS Office online, client workstations and browsers were all set to en-AU) But we prefer to set it to en-au even if  there are no issues with en-US